### PR TITLE
Use ubuntu:eoan as base to mitigate vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY velero-plugin-for-aws velero-plugin-for-aws
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /go/bin/velero-plugin-for-aws ./velero-plugin-for-aws
 
 
-FROM ubuntu:bionic
+FROM ubuntu:eoan
 RUN mkdir /plugins
 COPY --from=build /go/bin/velero-plugin-for-aws /plugins/
 USER nobody:nogroup


### PR DESCRIPTION
Bump base layer to use Ubuntu 19.10 to mitigate vulnerabilities